### PR TITLE
Fixes broken markdown in OAuth2 section

### DIFF
--- a/FLOWS.md
+++ b/FLOWS.md
@@ -416,9 +416,10 @@ OAuth2 three-legged cuts out a lot of clutter just like the two-legged, no longe
     
     Example Authorization URL (Not-Encoded for Readability):
     
-    ```
+```
 https://oauth_service/login/oauth/authorize?client_id=3MVG9lKcPoNINVB&redirect_uri=http://localhost/oauth/code_callback&scope=user
-    ```
+```
+
 2. User logs into the Service and grants Application access.
 3. Service redirects User back to the `redirect_uri` with:
     - `code`


### PR DESCRIPTION
As per the picture below:

<img width="855" alt="Screenshot 2020-04-25 at 10 46 23" src="https://user-images.githubusercontent.com/205629/80276659-14ec9000-86e2-11ea-9048-32e76d3e6d62.png">
